### PR TITLE
Papiere spawnen nurnoch unten

### DIFF
--- a/src/main/java/de/wolc/gui/PapierObjekt.java
+++ b/src/main/java/de/wolc/gui/PapierObjekt.java
@@ -17,25 +17,13 @@ public class PapierObjekt {
     private static final Random RANDOM = new Random();
 
     public double zufallsBreite() {
-        double halfWidth = this.game.getArea().getWidth() / 2d;
-        if (RANDOM.nextBoolean()) {
-            // links
-            return zufall(0, halfWidth / 2);
-        } else {
-            // rechts
-            return zufall(halfWidth + halfWidth / 2, halfWidth + halfWidth);
-        }
+        double versetzung = IMAGE.getWidth() / 2d;
+        return zufall(-versetzung, this.game.getArea().getWidth() - versetzung);
     }
 
     public double zufallsHoehe() {
         double halfHeight = this.game.getArea().getHeight() / 2d;
-        if (RANDOM.nextBoolean()) {
-            // oben
-            return zufall(0, halfHeight / 2);
-        } else {
-            // unten
-            return zufall(halfHeight + halfHeight / 2, halfHeight + halfHeight);
-        }
+        return zufall(halfHeight + IMAGE.getHeight(), halfHeight + halfHeight - IMAGE.getHeight());
     }
 
     public double zufall(double min, double max) {


### PR DESCRIPTION
Mit diesem PR spawnen Papiere nurnoch unten im Bild. Bitte mit euren Bildschirmauflösungen testen & Feedback geben was ihr davon haltet.

![screenshot from 2018-11-05 22-34-07](https://user-images.githubusercontent.com/7840502/48028200-30a95280-e14b-11e8-8ad5-1fde221a2013.png)

Fixes #58 